### PR TITLE
Black Duck: Upgrade Newtonsoft.Json to version 13.0.1 fix known security vulerabilities

### DIFF
--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -18,10 +18,10 @@
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
-<PackageReference Include="Selenium.WebDriver" Version="4.0.1"
+    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.UITest" Version="3.0.14" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade Newtonsoft.Json from version 12.0.3 to 13.0.1 in order to fix security vulnerabilities:

The direct dependency Newtonsoft.Json/12.0.3 has 1 vulnerabilities (max score 6.7).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description |
| --- | --- | --- | --- | --- | --- |
| -/- | Newtonsoft.Json/12.0.3 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-5195/overview" target="_blank">BDSA-2018-5195</a> | 6.7 | Vulnerabilities | Newtonsoft.Json is vulnerable to denial-of-service (DoS) due to a stack overflow that can occur whenever nested objects are being processed. A remote attacker could cause a vulnerable application  ... |
